### PR TITLE
Remove deprecated imports from Django Rest Framework

### DIFF
--- a/angular_dynamic_forms/__init__.py
+++ b/angular_dynamic_forms/__init__.py
@@ -1,6 +1,10 @@
 from .autocomplete import AutoCompleteMixin, autocomplete
 from .rest import AngularFormMixin
-from .foreign_key import foreign_field_autocomplete, ForeignFieldAutoCompleteMixin, M2MEnabledMetadata
+from .foreign_key import (
+    foreign_field_autocomplete,
+    ForeignFieldAutoCompleteMixin,
+    M2MEnabledMetadata,
+)
 from .linked_form import linked_form, linked_forms
 
 __all__ = [
@@ -11,5 +15,5 @@ __all__ = [
     ForeignFieldAutoCompleteMixin,
     M2MEnabledMetadata,
     linked_form,
-    linked_forms
+    linked_forms,
 ]

--- a/angular_dynamic_forms/autocomplete.py
+++ b/angular_dynamic_forms/autocomplete.py
@@ -5,7 +5,7 @@ from urllib.parse import urlsplit
 
 from django.template import Template, Context
 from rest_framework import renderers
-from rest_framework.decorators import detail_route, list_route, action
+from rest_framework.decorators import action
 from rest_framework.response import Response
 
 

--- a/angular_dynamic_forms/autocomplete.py
+++ b/angular_dynamic_forms/autocomplete.py
@@ -16,7 +16,7 @@ class AutoCompleteMixin(object):
         class __DummyFormatter:
             # noinspection PyMethodMayBeStatic
             def render(self, context):
-                return str(context['item'])
+                return str(context["item"])
 
         def __init__(self, search_method, formatter):
             self.search_method = search_method
@@ -26,34 +26,43 @@ class AutoCompleteMixin(object):
                 self.formatter = self.__DummyFormatter()
 
     # noinspection PyUnusedLocal
-    @action(detail=True, renderer_classes=[renderers.JSONRenderer], url_path='autocomplete/(?P<autocomplete_id>.*)',
-                  methods=['get', 'post'])
+    @action(
+        detail=True,
+        renderer_classes=[renderers.JSONRenderer],
+        url_path="autocomplete/(?P<autocomplete_id>.*)",
+        methods=["get", "post"],
+    )
     def autocomplete(self, request, *args, **kwargs):
         return self._autocomplete(request, has_instance=True, **kwargs)
 
     # noinspection PyUnusedLocal
-    @action(detail=False, renderer_classes=[renderers.JSONRenderer], url_path='autocomplete/(?P<autocomplete_id>.*)',
-                methods=['get', 'post'])
+    @action(
+        detail=False,
+        renderer_classes=[renderers.JSONRenderer],
+        url_path="autocomplete/(?P<autocomplete_id>.*)",
+        methods=["get", "post"],
+    )
     def autocomplete_list(self, request, *args, **kwargs):
         return self._autocomplete(request, has_instance=False, **kwargs)
 
     def _autocomplete_definitions(self):
-        if hasattr(self, '_autocomplete_definitions_cache'):
+        if hasattr(self, "_autocomplete_definitions_cache"):
             return self._autocomplete_definitions_cache
 
         ret = {}
         for method_name, method in inspect.getmembers(self, inspect.ismethod):
-            if not hasattr(method, '_autocomplete_field'):
+            if not hasattr(method, "_autocomplete_field"):
                 continue
             # noinspection PyUnresolvedReferences,PyProtectedMember
-            ret[method._autocomplete_field] = \
-                AutoCompleteMixin.__AutoCompleteRec(method, method._autocomplete_formatter)
+            ret[method._autocomplete_field] = AutoCompleteMixin.__AutoCompleteRec(
+                method, method._autocomplete_formatter
+            )
         self._autocomplete_definitions_cache = ret
         return ret
 
     def _decorate_layout_item(self, item):
         super()._decorate_layout_item(item)
-        name = item.get('id', None)
+        name = item.get("id", None)
         if name in self._autocomplete_definitions():
 
             # noinspection PyUnresolvedReferences
@@ -62,32 +71,33 @@ class AutoCompleteMixin(object):
             path = request.path
 
             # must be called from /form/ ...
-            path = re.sub(r'/form(/[^/]+)?/?$', '', path)
-            path = '%s/autocomplete/%s/' % (path, name)
-            item['autocomplete_url'] = urlsplit(request.build_absolute_uri(path)).path
+            path = re.sub(r"/form(/[^/]+)?/?$", "", path)
+            path = "%s/autocomplete/%s/" % (path, name)
+            item["autocomplete_url"] = urlsplit(request.build_absolute_uri(path)).path
 
     # noinspection PyUnusedLocal
     def _autocomplete(self, request, has_instance, **kwargs):
-        name = kwargs['autocomplete_id']
+        name = kwargs["autocomplete_id"]
         autocomplete_definitions = self._autocomplete_definitions()
         qs = autocomplete_definitions[name].search_method
-        query = request.GET['query']
-        qs = qs(query)[:self.max_returned_items]
+        query = request.GET["query"]
+        qs = qs(query)[: self.max_returned_items]
         formatter = autocomplete_definitions[name].formatter
-        qs = [{
-            'id'    : getattr(item, 'id', None) or item.get('id', None),
-            'label' : formatter.render(context=Context({'item': item}))
-        } for item in qs]
+        qs = [
+            {
+                "id": getattr(item, "id", None) or item.get("id", None),
+                "label": formatter.render(context=Context({"item": item})),
+            }
+            for item in qs
+        ]
         return Response(qs)
 
     @lru_cache(maxsize=None)
     def _serializer_with_id(self, serializer):
-        meta = type('Meta', (serializer.Meta,), {
-            'fields': serializer.Meta.fields + ('id',)
-        })
-        clz = type('_clz', (serializer,), {
-            'Meta': meta
-        })
+        meta = type(
+            "Meta", (serializer.Meta,), {"fields": serializer.Meta.fields + ("id",)}
+        )
+        clz = type("_clz", (serializer,), {"Meta": meta})
         return clz
 
 

--- a/angular_dynamic_forms/decorators.py
+++ b/angular_dynamic_forms/decorators.py
@@ -8,4 +8,5 @@ def form_action(form_id=None, **kwargs):
     def wrapper(func):
         func.angular_form_id = form_id
         return action(**kwargs)(func)
+
     return wrapper

--- a/angular_dynamic_forms/foreign_key.py
+++ b/angular_dynamic_forms/foreign_key.py
@@ -6,7 +6,7 @@ from urllib.parse import urlsplit
 from django.db.models import ManyToManyField
 from django.http import HttpResponseNotFound, HttpResponseNotAllowed
 from rest_framework import renderers, serializers
-from rest_framework.decorators import detail_route, list_route, action
+from rest_framework.decorators import action
 from rest_framework.metadata import SimpleMetadata
 from rest_framework.response import Response
 from rest_framework.serializers import ListSerializer, ModelSerializer

--- a/angular_dynamic_forms/foreign_key.py
+++ b/angular_dynamic_forms/foreign_key.py
@@ -16,8 +16,10 @@ import django.db.models
 class M2MEnabledMetadata(SimpleMetadata):
     def get_field_info(self, field):
         ret = super().get_field_info(field)
-        if isinstance(field, serializers.ManyRelatedField) or isinstance(field, ListSerializer):
-            ret['multiple'] = True
+        if isinstance(field, serializers.ManyRelatedField) or isinstance(
+            field, ListSerializer
+        ):
+            ret["multiple"] = True
         return ret
 
 
@@ -32,36 +34,48 @@ class ForeignFieldAutoCompleteMixin(object):
             self.pagination = pagination
 
     # noinspection PyUnusedLocal
-    @action(detail=True, renderer_classes=[renderers.JSONRenderer], url_path='foreign-autocomplete/(?P<autocomplete_id>.*)',
-                  methods=['get', 'post'])
+    @action(
+        detail=True,
+        renderer_classes=[renderers.JSONRenderer],
+        url_path="foreign-autocomplete/(?P<autocomplete_id>.*)",
+        methods=["get", "post"],
+    )
     def foreign_autocomplete(self, request, *args, **kwargs):
         return self._foreign_autocomplete(request, has_instance=True, **kwargs)
 
     # noinspection PyUnusedLocal
-    @action(detail=False, renderer_classes=[renderers.JSONRenderer], url_path='foreign-autocomplete/(?P<autocomplete_id>.*)',
-                methods=['get', 'post'])
+    @action(
+        detail=False,
+        renderer_classes=[renderers.JSONRenderer],
+        url_path="foreign-autocomplete/(?P<autocomplete_id>.*)",
+        methods=["get", "post"],
+    )
     def foreign_autocomplete_list(self, request, *args, **kwargs):
         return self._foreign_autocomplete(request, has_instance=False, **kwargs)
 
     def _foreign_autocomplete_definitions(self):
-        if hasattr(self, '_foreign_autocomplete_definitions_cache'):
+        if hasattr(self, "_foreign_autocomplete_definitions_cache"):
             return self._foreign_autocomplete_definitions_cache
 
         ret = {}
 
         for method_name, method in inspect.getmembers(self, inspect.ismethod):
-            if not hasattr(method, '_foreign_autocomplete_field'):
+            if not hasattr(method, "_foreign_autocomplete_field"):
                 continue
             # noinspection PyUnresolvedReferences,PyProtectedMember
-            ret[method._foreign_autocomplete_field] = \
-                ForeignFieldAutoCompleteMixin.__AutoCompleteRec(method, method._foreign_autocomplete_serializer,
-                                                                method._foreign_autocomplete_pagination)
+            ret[
+                method._foreign_autocomplete_field
+            ] = ForeignFieldAutoCompleteMixin.__AutoCompleteRec(
+                method,
+                method._foreign_autocomplete_serializer,
+                method._foreign_autocomplete_pagination,
+            )
         self._foreign_autocomplete_definitions_cache = ret
         return ret
 
     def _decorate_layout_item(self, item):
         super()._decorate_layout_item(item)
-        item_id = item.get('id', None)
+        item_id = item.get("id", None)
         if item_id in self._foreign_autocomplete_definitions():
 
             # noinspection PyUnresolvedReferences
@@ -70,17 +84,17 @@ class ForeignFieldAutoCompleteMixin(object):
             path = request.path
 
             # must be called from /form/ or /form/<formid>/
-            path = re.sub(r'/form(/[^/]+)?/?$', '', path)
-            path = '%s/foreign-autocomplete/%s/' % (path, item_id)
-            item['autocomplete_url'] = urlsplit(request.build_absolute_uri(path)).path
+            path = re.sub(r"/form(/[^/]+)?/?$", "", path)
+            path = "%s/foreign-autocomplete/%s/" % (path, item_id)
+            item["autocomplete_url"] = urlsplit(request.build_absolute_uri(path)).path
 
             # convert nested object (there was serializer for that) into a field
-            if item.get('type') == 'nested object':
-                item['type'] = 'field'
+            if item.get("type") == "nested object":
+                item["type"] = "field"
 
     # noinspection PyUnusedLocal
     def _foreign_autocomplete(self, request, has_instance, **kwargs):
-        item_id = kwargs['autocomplete_id']
+        item_id = kwargs["autocomplete_id"]
         foreign_autocomplete_definitions = self._foreign_autocomplete_definitions()
         if item_id not in foreign_autocomplete_definitions:
             return HttpResponseNotFound()
@@ -89,22 +103,21 @@ class ForeignFieldAutoCompleteMixin(object):
         paginated = foreign_autocomplete_definitions[item_id].pagination
         total = 0
         if paginated:
-            pageIndex = int(request.GET.get('pageIndex', 0))
-            pageSize = int(request.GET.get('pageSize', 0))
+            pageIndex = int(request.GET.get("pageIndex", 0))
+            pageSize = int(request.GET.get("pageSize", 0))
             if pageSize > self.max_returned_items:
-                return HttpResponseNotAllowed('pageSize too big')
+                return HttpResponseNotAllowed("pageSize too big")
             total = qs.count()
             if pageSize:
                 qs = qs[pageIndex * pageSize : (pageIndex + 1) * pageSize]
         else:
-            qs = qs[:self.max_returned_items]
+            qs = qs[: self.max_returned_items]
 
-        serializer = foreign_autocomplete_definitions[item_id].serializer(many=True, instance=qs)
+        serializer = foreign_autocomplete_definitions[item_id].serializer(
+            many=True, instance=qs
+        )
         if paginated:
-            return Response({
-                'length' : total,
-                'items'  : serializer.data
-            })
+            return Response({"length": total, "items": serializer.data})
         else:
             return Response(serializer.data)
 
@@ -120,7 +133,6 @@ def foreign_field_autocomplete(field, serializer, pagination=False):
 
 
 class ForeignSerializerMixin:
-
     def to_internal_value(self, data):
         self.__original_data = data
         return super().to_internal_value(data)
@@ -155,7 +167,9 @@ class ForeignSerializerMixin:
                         elif isinstance(v[0], dict):
                             related_model = field.related_model
                             # convert the dict to model instances
-                            v = [vv['id'] for vv in self.__original_data.get(k, [])]  # validation strips id, why???
+                            v = [
+                                vv["id"] for vv in self.__original_data.get(k, [])
+                            ]  # validation strips id, why???
                             v = set(related_model.objects.filter(pk__in=v))
 
                     else:
@@ -172,5 +186,7 @@ class ForeignSerializerMixin:
                 elif isinstance(self.fields[k], ModelSerializer):
                     related_model = field.related_model
                     orig = self.__original_data.get(k, {})
-                    validated_data[k] = related_model.objects.get(pk=orig.get('id', None))
+                    validated_data[k] = related_model.objects.get(
+                        pk=orig.get("id", None)
+                    )
         return delayed_m2m

--- a/angular_dynamic_forms/foreign_key.py
+++ b/angular_dynamic_forms/foreign_key.py
@@ -16,7 +16,6 @@ import django.db.models
 class M2MEnabledMetadata(SimpleMetadata):
     def get_field_info(self, field):
         ret = super().get_field_info(field)
-        print('field', field)
         if isinstance(field, serializers.ManyRelatedField) or isinstance(field, ListSerializer):
             ret['multiple'] = True
         return ret

--- a/angular_dynamic_forms/linked_form.py
+++ b/angular_dynamic_forms/linked_form.py
@@ -1,6 +1,5 @@
 from functools import wraps
 
-from rest_framework.decorators import detail_route
 from rest_framework.relations import PrimaryKeyRelatedField
 from rest_framework.decorators import action
 

--- a/angular_dynamic_forms/linked_form.py
+++ b/angular_dynamic_forms/linked_form.py
@@ -4,6 +4,7 @@ from rest_framework.decorators import detail_route
 from rest_framework.relations import PrimaryKeyRelatedField
 from rest_framework.decorators import action
 
+
 def linked_form(viewset, form_id=None, link=None, link_id=None, method=None):
     """
     When having foreign key or m2m relationships between models A and B (B has foreign key to A named parent),
@@ -27,59 +28,65 @@ def linked_form(viewset, form_id=None, link=None, link_id=None, method=None):
     :return:            an internal definition of a linked form
     """
     return {
-        'viewset' : viewset,
-        'form_id' : form_id,
-        'link'    : link,
-        'link_id' : link_id,
-        'method'  : method
+        "viewset": viewset,
+        "form_id": form_id,
+        "link": link,
+        "link_id": link_id,
+        "method": method,
     }
 
 
 def linked_forms():
     def build_form(clz, form_name, form_def):
         def form_method(self, request, pk, *args, **kwargs):
-            viewset = form_def['viewset']()
+            viewset = form_def["viewset"]()
             viewset.request = request
             viewset.format_kwarg = self.format_kwarg
-            link = form_def['link']
+            link = form_def["link"]
             if isinstance(link, str):
                 serializer = viewset.get_serializer()
                 fld = serializer.fields[link]
                 if isinstance(fld, PrimaryKeyRelatedField):
                     request.data[link] = self.get_object().pk
                 else:
-                    request.data[link] = self.get_serializer(instance=self.get_object()).data
+                    request.data[link] = self.get_serializer(
+                        instance=self.get_object()
+                    ).data
 
-            method = form_def['method']
-            if 'link_id' in form_def:
-                link_id = request.GET.get(form_def['link_id']) or request.data.get(form_def['link_id'])
-                viewset.lookup_url_kwarg = form_def['link_id']
-                viewset.kwargs = {
-                    viewset.lookup_url_kwarg: link_id
-                }
+            method = form_def["method"]
+            if "link_id" in form_def:
+                link_id = request.GET.get(form_def["link_id"]) or request.data.get(
+                    form_def["link_id"]
+                )
+                viewset.lookup_url_kwarg = form_def["link_id"]
+                viewset.kwargs = {viewset.lookup_url_kwarg: link_id}
             else:
                 link_id = None
 
-            if request._request.method == 'GET':
-                method = 'retrieve'
+            if request._request.method == "GET":
+                method = "retrieve"
             elif not method:
-                method = 'create' if not link_id else 'update'
+                method = "create" if not link_id else "update"
 
             return getattr(viewset, method)(request, *args, **kwargs)
 
-        form_method.__name__ = form_name.replace('-', '_')
+        form_method.__name__ = form_name.replace("-", "_")
 
         return (
-            form_name.replace('-', '_'),
-            action(methods=['get', 'post', 'patch'], detail=True, url_path=form_name)(form_method))
+            form_name.replace("-", "_"),
+            action(methods=["get", "post", "patch"], detail=True, url_path=form_name)(
+                form_method
+            ),
+        )
 
     def wrapper(clz):
-        forms = getattr(clz, 'linked_forms', {})
+        forms = getattr(clz, "linked_forms", {})
         if forms:
             new_methods = []
             for form_name, form_def in forms.items():
                 new_methods.append(build_form(clz, form_name, form_def))
-            clz = type('%s_linked' % clz.__name__, (clz, ), dict(new_methods))
+            clz = type("%s_linked" % clz.__name__, (clz,), dict(new_methods))
 
         return clz
+
     return wrapper

--- a/angular_dynamic_forms/logging.py
+++ b/angular_dynamic_forms/logging.py
@@ -2,19 +2,24 @@ class LoggerDecorator:
     """
     Just for debugging the library, not intended for other uses
     """
+
     level = 0
 
     @classmethod
     def log(clz):
         def _decorator(fn):
-            def _decorated(*arg,**kwargs):
+            def _decorated(*arg, **kwargs):
                 clz.level += 1
                 try:
-                    print("%s > '%s'(%r,%r)" % (' ' * clz.level, fn.__name__, arg, kwargs))
-                    ret=fn(*arg,**kwargs)
-                    print("%s < %r" % (' ' * clz.level, ret))
+                    print(
+                        "%s > '%s'(%r,%r)" % (" " * clz.level, fn.__name__, arg, kwargs)
+                    )
+                    ret = fn(*arg, **kwargs)
+                    print("%s < %r" % (" " * clz.level, ret))
                     return ret
                 finally:
                     clz.level -= 1
+
             return _decorated
+
         return _decorator

--- a/angular_dynamic_forms/rest.py
+++ b/angular_dynamic_forms/rest.py
@@ -60,8 +60,8 @@ class AngularFormMixin(object):
     """
     These three is a map from form_id => layout, title, map of defaults for the case of multiple forms per viewset
     """
-    form_layouts  = {}
-    form_titles   = {}
+    form_layouts = {}
+    form_titles = {}
     form_defaults_map = {}
 
     """
@@ -79,11 +79,7 @@ class AngularFormMixin(object):
         :param controls:    a list of controls
         :return:            fieldset record
         """
-        return {
-            'type': 'fieldset',
-            'label': title,
-            'controls': controls
-        }
+        return {"type": "fieldset", "label": title, "controls": controls}
 
     @staticmethod
     def columns(*controls):
@@ -95,10 +91,7 @@ class AngularFormMixin(object):
                             the components or .group(*controls) method
         :return:            record for a multiple columns layout
         """
-        return {
-            'type': 'columns',
-            'columns': controls
-        }
+        return {"type": "columns", "columns": controls}
 
     @staticmethod
     def group(*controls):
@@ -110,38 +103,62 @@ class AngularFormMixin(object):
         """
         return controls
 
-
     # noinspection PyUnusedLocal
-    @action(detail=True, renderer_classes=[renderers.JSONRenderer], url_path='form')
+    @action(detail=True, renderer_classes=[renderers.JSONRenderer], url_path="form")
     def form(self, request, *args, **kwargs):
-        return Response(self._get_form_metadata(has_instance=True,
-                                                base_path=self._base_path(request.path)))
+        return Response(
+            self._get_form_metadata(
+                has_instance=True, base_path=self._base_path(request.path)
+            )
+        )
 
     # noinspection PyUnusedLocal
-    @action(detail=False, renderer_classes=[renderers.JSONRenderer], url_path='form')
+    @action(detail=False, renderer_classes=[renderers.JSONRenderer], url_path="form")
     def form_list(self, request, *args, **kwargs):
-        return Response(self._get_form_metadata(has_instance=False,
-                                                base_path=self._base_path(request.path)))
+        return Response(
+            self._get_form_metadata(
+                has_instance=False, base_path=self._base_path(request.path)
+            )
+        )
 
     # noinspection PyUnusedLocal
-    @action(detail=True, renderer_classes=[renderers.JSONRenderer], url_path='form/(?P<form_name>.+)')
+    @action(
+        detail=True,
+        renderer_classes=[renderers.JSONRenderer],
+        url_path="form/(?P<form_name>.+)",
+    )
     def form_with_name(self, request, *args, form_name=None, **kwargs):
-        return Response(self._get_form_metadata(has_instance=True, form_name =form_name or '',
-                                                base_path=self._base_path(request.path, 2)))
+        return Response(
+            self._get_form_metadata(
+                has_instance=True,
+                form_name=form_name or "",
+                base_path=self._base_path(request.path, 2),
+            )
+        )
 
     # noinspection PyUnusedLocal
-    @action(detail=False, renderer_classes=[renderers.JSONRenderer], url_path='form/(?P<form_name>.+)')
+    @action(
+        detail=False,
+        renderer_classes=[renderers.JSONRenderer],
+        url_path="form/(?P<form_name>.+)",
+    )
     def form_list_with_name(self, request, *args, form_name=None, **kwargs):
-        return Response(self._get_form_metadata(has_instance=False, form_name =form_name or '',
-                                                base_path=self._base_path(request.path, 2)))
+        return Response(
+            self._get_form_metadata(
+                has_instance=False,
+                form_name=form_name or "",
+                base_path=self._base_path(request.path, 2),
+            )
+        )
 
     @staticmethod
     def _base_path(path, level=1):
-        if path.endswith('/'):
+        if path.endswith("/"):
             path = path[:-1]
         for _lev in range(level):
             path = os.path.dirname(path)
-        return path + '/'
+        return path + "/"
+
     #
     # the rest of the methods on this class are private ones
     #
@@ -167,8 +184,11 @@ class AngularFormMixin(object):
                 layout = form_layout
         else:
             # no layout, generate from fields
-            layout = [self._get_field_layout(field_name, fields[field_name])
-                        for field_name in fields if not fields[field_name]['read_only']]
+            layout = [
+                self._get_field_layout(field_name, fields[field_name])
+                for field_name in fields
+                if not fields[field_name]["read_only"]
+            ]
 
         layout = self._transform_layout(layout, form_defaults, wrap_array=False)
 
@@ -188,7 +208,7 @@ class AngularFormMixin(object):
         return x
 
     def _get_field_layout(self, field_name, field):
-        return {'id': field_name}
+        return {"id": field_name}
 
     # @LoggerDecorator.log()
     def _transform_layout(self, layout, form_defaults, wrap_array=True):
@@ -196,33 +216,37 @@ class AngularFormMixin(object):
         if isinstance(layout, dict):
             layout = layout.copy()
 
-            if 'id' in layout and layout['id'] in form_defaults:
-                layout.update(form_defaults[layout['id']])
+            if "id" in layout and layout["id"] in form_defaults:
+                layout.update(form_defaults[layout["id"]])
 
             for (k, v) in list(layout.items()):
                 if callable(v):
                     layout[k] = v(self)
 
-            layout_type = layout.get('type', 'string')
+            layout_type = layout.get("type", "string")
 
-            if layout_type in ('fieldset', 'group'):
-                layout['controls'] = self._transform_layout(layout['controls'], form_defaults, wrap_array=False)
+            if layout_type in ("fieldset", "group"):
+                layout["controls"] = self._transform_layout(
+                    layout["controls"], form_defaults, wrap_array=False
+                )
                 return layout
 
-            if layout_type == 'columns':
-                layout['controls'] = self._transform_layout(layout['columns'], form_defaults, wrap_array=False)
-                del layout['columns']
+            if layout_type == "columns":
+                layout["controls"] = self._transform_layout(
+                    layout["columns"], form_defaults, wrap_array=False
+                )
+                del layout["columns"]
                 return layout
 
-            if layout_type == 'string':
+            if layout_type == "string":
                 # string or textarea?
                 qs = self.get_queryset()
                 model = qs.model
                 if model:
                     try:
-                        field = model._meta.get_field(layout['id'])
+                        field = model._meta.get_field(layout["id"])
                         if isinstance(field, TextField):
-                            layout['type'] = 'textarea'
+                            layout["type"] = "textarea"
                     except FieldDoesNotExist:
                         pass
             return layout
@@ -231,16 +255,16 @@ class AngularFormMixin(object):
             # otherwise it is a group of controls
             if wrap_array:
                 return {
-                    'type': 'group',
-                    'controls': [self._transform_layout(l, form_defaults) for l in layout]
+                    "type": "group",
+                    "controls": [
+                        self._transform_layout(l, form_defaults) for l in layout
+                    ],
                 }
             else:
                 return [self._transform_layout(l, form_defaults) for l in layout]
 
         if isinstance(layout, str):
-            return self._transform_layout({
-                'id': layout
-            }, form_defaults)
+            return self._transform_layout({"id": layout}, form_defaults)
 
         raise NotImplementedError('Layout "%s" not implemented' % layout)
 
@@ -250,14 +274,14 @@ class AngularFormMixin(object):
             form_title = self.form_titles.get(form_name, None)
 
         if form_title:
-            return form_title['edit' if has_instance else 'create']
+            return form_title["edit" if has_instance else "create"]
 
         # noinspection PyProtectedMember
         name = serializer.Meta.model._meta.verbose_name
         if has_instance:
-            name = gettext('Editing %s') % name
+            name = gettext("Editing %s") % name
         else:
-            name = gettext('Creating a new %s') % name
+            name = gettext("Creating a new %s") % name
 
         return name
 
@@ -265,32 +289,16 @@ class AngularFormMixin(object):
     def _get_actions(self, has_instance, serializer):
         if has_instance:
             return [
-                {
-                    'id': 'save',
-                    'color': 'primary',
-                    'label': gettext('Save')
-                },
-                {
-                    'id': 'cancel',
-                    'label': gettext('Cancel'),
-                    'cancel': True
-                },
+                {"id": "save", "color": "primary", "label": gettext("Save")},
+                {"id": "cancel", "label": gettext("Cancel"), "cancel": True},
             ]
         else:
             return [
-                {
-                    'id': 'create',
-                    'color': 'primary',
-                    'label': gettext('Create')
-                },
-                {
-                    'id': 'cancel',
-                    'label': gettext('Cancel'),
-                    'cancel': True
-                },
+                {"id": "create", "color": "primary", "label": gettext("Create")},
+                {"id": "cancel", "label": gettext("Cancel"), "cancel": True},
             ]
 
-    def _get_form_metadata(self, has_instance, form_name='', base_path=None):
+    def _get_form_metadata(self, has_instance, form_name="", base_path=None):
 
         if form_name:
 
@@ -298,11 +306,13 @@ class AngularFormMixin(object):
                 return self._linked_form_metadata(form_name)
 
             if not self.form_layouts:
-                raise Http404('Form layouts not configured. '
-                                            'Please add form_layouts attribute on the viewset class')
+                raise Http404(
+                    "Form layouts not configured. "
+                    "Please add form_layouts attribute on the viewset class"
+                )
 
             if form_name not in self.form_layouts:
-                raise Http404('Form with name %s not found' % form_name)
+                raise Http404("Form with name %s not found" % form_name)
 
         ret = {}
 
@@ -316,19 +326,21 @@ class AngularFormMixin(object):
         layout = self._get_form_layout(fields_info, form_name)
         layout = self._decorate_layout(layout, fields_info)
 
-        ret['layout'] = self._convert_camel_case(layout)
+        ret["layout"] = self._convert_camel_case(layout)
 
-        ret['formTitle'] = self._get_form_title(has_instance, serializer, form_name)
+        ret["formTitle"] = self._get_form_title(has_instance, serializer, form_name)
 
-        ret['actions'] = self._get_actions(has_instance, serializer)
+        ret["actions"] = self._get_actions(has_instance, serializer)
 
-        ret['method'] = 'patch' if has_instance else 'post'
-        ret['hasInitialData'] = has_instance
+        ret["method"] = "patch" if has_instance else "post"
+        ret["hasInitialData"] = has_instance
 
-        if getattr(settings, 'ANGULAR_FORM_ABSOLUTE_URLS', False):
-            ret['djangoUrl'] = self.request.build_absolute_uri(base_path + self._get_url_by_form_id(form_name))
+        if getattr(settings, "ANGULAR_FORM_ABSOLUTE_URLS", False):
+            ret["djangoUrl"] = self.request.build_absolute_uri(
+                base_path + self._get_url_by_form_id(form_name)
+            )
         else:
-            ret['djangoUrl'] = base_path + self._get_url_by_form_id(form_name)
+            ret["djangoUrl"] = base_path + self._get_url_by_form_id(form_name)
 
         # print(json.dumps(ret, indent=4))
         return ret
@@ -336,35 +348,42 @@ class AngularFormMixin(object):
     @functools.lru_cache(maxsize=16)
     def _get_url_by_form_id(self, form_id):
         if not form_id:
-            return ''
-        method = inspect.getmembers(self, lambda fld: callable(fld) and getattr(fld, 'angular_form_id', None) == form_id)
+            return ""
+        method = inspect.getmembers(
+            self,
+            lambda fld: callable(fld)
+            and getattr(fld, "angular_form_id", None) == form_id,
+        )
         if not method:
-            return ''
+            return ""
         ret = method[0][1].url_path
-        if not ret.endswith('/'):
-            ret += '/'
+        if not ret.endswith("/"):
+            ret += "/"
         return ret
 
     def _linked_form_metadata(self, form_name):
         request = self.request
 
         form_def = self.linked_forms[form_name]
-        viewset = form_def['viewset']()
+        viewset = form_def["viewset"]()
         viewset.request = request
         viewset.format_kwarg = self.format_kwarg
 
-        if 'link_id' in form_def:
-            link_id = request.GET.get(form_def['link_id']) or request.data.get(form_def['link_id'])
+        if "link_id" in form_def:
+            link_id = request.GET.get(form_def["link_id"]) or request.data.get(
+                form_def["link_id"]
+            )
         else:
             link_id = None
 
-
         path = request.path
         # must be called from /form/ ...
-        path = re.sub(r'/form(/[^/]+)?/?$', '', path)
-        path = '%s/%s/' % (path, form_name)
+        path = re.sub(r"/form(/[^/]+)?/?$", "", path)
+        path = "%s/%s/" % (path, form_name)
 
-        ret = viewset._get_form_metadata(link_id, form_name=form_def['form_id'], base_path=path)
+        ret = viewset._get_form_metadata(
+            link_id, form_name=form_def["form_id"], base_path=path
+        )
 
         return ret
 
@@ -376,22 +395,26 @@ class AngularFormMixin(object):
                 ret.append(self._decorate_layout(it, fields_info))
             return ret
         elif isinstance(layout, dict):
-            if layout.get('type', None) in ('fieldset', 'columns', 'group'):
+            if layout.get("type", None) in ("fieldset", "columns", "group"):
                 layout = dict(layout)
-                layout['controls'] = self._decorate_layout(layout['controls'], fields_info)
+                layout["controls"] = self._decorate_layout(
+                    layout["controls"], fields_info
+                )
                 self._decorate_layout_item(layout)
                 return layout
             else:
-                md = dict(fields_info.get(layout['id'], {}))
+                md = dict(fields_info.get(layout["id"], {}))
                 md.update(layout)
-                if md['type'] == 'choice':
-                    md['type'] = 'select'
-                if md.get('choices'):
-                    md['choices'] = [
+                if md["type"] == "choice":
+                    md["type"] = "select"
+                if md.get("choices"):
+                    md["choices"] = [
                         {
-                            'label': x.get('label', None) or x.get('display_name', None),
-                            'value': x['value']
-                        } for x in md['choices']
+                            "label": x.get("label", None)
+                            or x.get("display_name", None),
+                            "value": x["value"],
+                        }
+                        for x in md["choices"]
                     ]
                 self._decorate_layout_item(md)
                 return md
@@ -402,9 +425,7 @@ class AngularFormMixin(object):
 
 # privates
 def camel(snake_str):
-    if '_' not in snake_str:
+    if "_" not in snake_str:
         return snake_str
-    first, *others = snake_str.split('_')
-    return ''.join([first.lower(), *map(str.title, others)])
-
-
+    first, *others = snake_str.split("_")
+    return "".join([first.lower(), *map(str.title, others)])

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='6.1.3',
+    version='6.1.4',
 
     description='Django Rest Framework meets Angular 5 material.io dynamic forms - rapid development of create and edit dialogs',
     long_description=long_description,


### PR DESCRIPTION
Django Rest Framework finally deprecated `detail_route` and `list_route` decorators. They're no longer available and they weren't used the project anymore. This PR removes them and also:

- Adds support for Django Rest Framework 3.10.x
- Applied Black (Python standard code formatter)
- Removed unused print on `primary_key.py`
